### PR TITLE
PLA missing MAT backpack fix

### DIFF
--- a/FP_Factions/PLA/config.cpp
+++ b/FP_Factions/PLA/config.cpp
@@ -435,6 +435,23 @@ class cfgvehicles
 			};
 		};
 	};
+	class B_Kitbag_sgg_MAT: B_Kitbag_sgg
+	{
+		scope = 1;
+		class TransportMagazines
+		{
+			class _xx_RPG32_HE_F
+			{
+				magazine = "RPG32_HE_F";
+				count = 2;
+			};
+			class _xx_RPG32_F
+			{
+				magazine = "RPG32_F";
+				count = 2;
+			};
+		};
+	};
 	class B_FieldPack_cbr_MANPADS: B_Carryall_cbr
 	{
 		scope = 1;


### PR DESCRIPTION
- fixes an error when spawning FP_Faction_PLA_MAT and FP_Faction_PLA_AMAT; was missing a backpack in the config.